### PR TITLE
Fix integer field handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 .idea
+*.iml
 node_modules/
 public/config.json
 public/config.js

--- a/src/components/formPopup/formPopup.comp.tsx
+++ b/src/components/formPopup/formPopup.comp.tsx
@@ -181,6 +181,12 @@ export const FormPopup = withAppContext(({ context, title, fields, rawData, getS
         finalObject[field.name] = encodeURIComponent(field.value);
       }
 
+      // check if integer/number fields are empty;
+      // if so, set value to 'null' (otherwise would be rendered as string)
+      if ((field.type === 'integer' || field.type === 'number') && field.value === "") {
+        finalObject[field.name] = null;
+      }
+
       if (field.useInUrl) {
         queryParams.push({ name: field.name, value: field.value });
       }


### PR DESCRIPTION
This will fix the faulty rendering of empty integer/number fields.

Currently they get rendered like this ...
```
{
   "myIntegerField":"",
...
```
... when empty.

Which is wrong, since this is interpreted as a string by most backends.
The JSON-datatype "null" should be used instead (see: [JSON Data Types](https://www.w3schools.com/js/js_json_datatypes.asp)).
